### PR TITLE
Prevent navigation when clicking #lightConnect.

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -27,7 +27,7 @@
 // kick off the service worker update flow and the old cache(s) will be purged
 // as part of the activate event handler when the updated service worker is
 // activated.
-var CACHE_VERSION = 5;
+var CACHE_VERSION = 6;
 var CURRENT_CACHES = {
   'read-through': 'read-through-cache-v' + CACHE_VERSION
 };

--- a/weblight.js
+++ b/weblight.js
@@ -255,11 +255,12 @@ function startInitialConnections() {
   });
 }
 
-function requestConnection() {
+function requestConnection(event) {
   webusb.requestDevice().then(device => {
     console.log(device);
     connectDevice(device);
   });
+  event.preventDefault();
 }
 
 function start() {


### PR DESCRIPTION
If the frame is allowed to navigate then the navigator.usb.requestDevice
request will be cancelled immediately. Use event.preventDefault() to
make this link act more like a button.
