### PR TITLE
Prepare for the removal of USBDevice.guid.

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -27,7 +27,7 @@
 // kick off the service worker update flow and the old cache(s) will be purged
 // as part of the activate event handler when the updated service worker is
 // activated.
-var CACHE_VERSION = 7;
+var CACHE_VERSION = 8;
 var CURRENT_CACHES = {
   'read-through': 'read-through-cache-v' + CACHE_VERSION
 };


### PR DESCRIPTION
The guid attribute is going away and USBDevice instances will simply be
comparable. This patch updates weblight.js to work in both the case were
guid is available and where it is not.
