### PR TITLE
Remove CNAME.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-weblight.xyz


### PR DESCRIPTION
GitHub sometimes issues an HTTP 301 redirect from sowbug.github.io to
weblight.xyz. Since WebUSB can only be used from secure origins and we
don't have an SSL certificate for weblight.xyz (and GitHub doesn't
support HTTPS on custom domains anyways) it is best to remove the CNAME
for now.
