### PR TITLE
Use device serialNumber as dictionary key.

### DIFF
--- a/weblight.js
+++ b/weblight.js
@@ -34,24 +34,15 @@ function ab2str(buf) {
 
   webusb.Device = function(device) {
     this.device_ = device;
-    if (device.guid === undefined)
-      webusb.devices[device] = this
-    else
-      webusb.devices[device.guid] = this;
+    webusb.devices[device.serialNumber] = this;
   };
 
   webusb.deleteDevice = function(device) {
-    if (device.device_.guid === undefined)
-      delete webusb.devices[device.device_];
-    else
-      delete webusb.devices[device.device_.guid];
+    delete webusb.devices[device.device_.serialNumber];
   };
 
   webusb.getDevice = function(device) {
-    if (device.guid === undefined)
-      return webusb.devices[device];
-    else
-      return webusb.devices[device.guid];
+    return webusb.devices[device.serialNumber];
   };
 
   webusb.Device.prototype.connect = function() {


### PR DESCRIPTION
In 9b22f8a0e0ee45612cea9dfeecd1b0f1167b15d1 when I was preparing for the removal of the guid attribute from USBDevice I assumed that the USBDevice object itself could be used as a functional Object key. This is not the case (all objects stringify the to same value). So instead we should be using the device serial number since all WebLights have a valid and unique serial number.

This resolves issue #41.